### PR TITLE
Encode CSIDL strings as ascii_compatible

### DIFF
--- a/lib/win32/dir.rb
+++ b/lib/win32/dir.rb
@@ -110,7 +110,7 @@ class Dir
       end
     end
 
-    Dir.const_set(key, path) if path
+    Dir.const_set(key, path.encode(Encoding.default_external)) if path
   }
 
   # Set Dir::MYDOCUMENTS to the same as Dir::PERSONAL if undefined

--- a/test/test_win32_dir.rb
+++ b/test/test_win32_dir.rb
@@ -380,6 +380,11 @@ class TC_Win32_Dir < Test::Unit::TestCase
     assert_kind_of(String, Dir::WINDOWS)
   end
 
+  test "constants are ascii_compatible?" do
+    assert_true(Dir::COMMON_APPDATA.encoding.ascii_compatible?)
+    assert_nothing_raised{ File.join(Dir::COMMON_APPDATA, 'foo') }
+  end
+
   test "ffi functions are private" do
     assert_not_respond_to(Dir, :SHGetFolderPathW)
   end


### PR DESCRIPTION
Ruby does not allow `File.join` to be called with non-ascii_compatible
encoded strings, like `UTF-16LE`[1]. As a result, if any of the CSIDL
constants, e.g. COMMON_APPDATA, are used in `File.join` it fails with:

```
irb(main):001:0> require 'win32/dir'
irb(main):002:0> File.join(Dir::COMMON_APPDATA, 'foo')
ArgumentError: string contains null byte
```

The ffi branch calls the wide versions of `SHGetFolderPathW`, and appears
to always have this issue. The master branch calls the ANSI versions, which
only exhibit the problem when using a non-ASCII locale, e.g. Italian
(locale 0410).

This commit ensures all CSIDL constants are encoded using the default
external encoding, similar to what is done for `Dir::getwd`.

Note I suspect the junction code has the same problem, e.g. `read_junction`.

[1] https://bugs.ruby-lang.org/issues/7168
