### PR TITLE
Return ascii_compatible junction path

### DIFF
--- a/lib/win32/dir.rb
+++ b/lib/win32/dir.rb
@@ -287,10 +287,6 @@ class Dir
   # Raises +ENOENT+ if given path does not exist, returns +false+
   # if it is not a junction.
   #
-  # Note that regardless of the encoding of the string passed in,
-  # +read_junction()+ will always return a result as UTF-16LE, as it's
-  # actually written in the reparse point.
-  #
   # Example:
   #
   #    Dir.mkdir('C:/from')
@@ -368,7 +364,7 @@ class Dir
     jname = jname.bytes.to_a.pack('C*')
     jname = jname.force_encoding("UTF-16LE")
     raise "Junction name came back as #{jname}" unless jname[0..3] == "\\??\\".encode("UTF-16LE")
-    return jname[4..-1].gsub("\\".encode("UTF-16LE"), "/".encode("UTF-16LE"))
+    File.expand_path(jname[4..-1].encode(Encoding.default_external))
   end
 
   # Returns whether or not +path+ is empty.  Returns false if +path+ is not

--- a/test/test_win32_dir.rb
+++ b/test/test_win32_dir.rb
@@ -72,13 +72,19 @@ class TC_Win32_Dir < Test::Unit::TestCase
   test "read_junction works as expected with ascii characters" do
     assert_nothing_raised{ Dir.create_junction(@ascii_to, @@from) }
     assert_true(File.exists?(@ascii_to))
-    assert_equal(Dir.read_junction(@ascii_to), @@from.bytes.to_a.pack('C*').encode("UTF-16LE"))
+    assert_equal(Dir.read_junction(@ascii_to), @@from)
   end
 
   test "read_junction works as expected with unicode characters" do
     assert_nothing_raised{ Dir.create_junction(@unicode_to, @@from) }
     assert_true(File.exists?(@unicode_to))
-    assert_equal(Dir.read_junction(@unicode_to), @@from.bytes.to_a.pack('C*').encode("UTF-16LE"))
+    assert_equal(Dir.read_junction(@unicode_to), @@from)
+  end
+
+  test "read_junction with unicode characters is joinable" do
+    assert_nothing_raised{ Dir.create_junction(@unicode_to, @@from) }
+    assert_true(File.exists?(@unicode_to))
+    assert_nothing_raised{ File.join(Dir.read_junction(@unicode_to), 'foo') }
   end
 
   test "junction? method returns boolean value" do


### PR DESCRIPTION
Previously, calling `Dir.read_junction` would return a `UTF-16LE` encoded
string, which would cause failures when combining with `File.join`:

```
C:\> ruby -rwin32/dir -e "p File.join(Dir.read_junction('c:/to'), 'a')"
-e:1:in `join': string contains null byte (ArgumentError)
```

For the same reasons as mentioned in d92e3b4e7f.

This commit modifies the `read_junction` method to return the junction path
encoded in the default external encoding, similar to what is done for
`Dir.getwd` and the CSIDL constants.
