### PR TITLE
Fix for ASCII 8-Bit encoding conversion failure

### DIFF
--- a/lib/win32/dir.rb
+++ b/lib/win32/dir.rb
@@ -88,6 +88,7 @@ class Dir
       if SHGetFolderLocation(0, value, 0, 0, ptr) == 0
         if SHGetFileInfo(ptr.read_long, 0, info, info.size, flags) != 0
           path = info[:szDisplayName].to_s
+          path.force_encoding(Encoding.default_external)
         end
       end
     end


### PR DESCRIPTION
We've found the following error with the latest version:
    win32-dir-0.4.3/lib/win32/dir.rb:95:in `encode': "\xE9" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to CP850 (Encoding::UndefinedConversionError)

This is when we have a character in the path like é (x00E9 if it doesn't 
show up appropriately).

This will force the default encoding of the machine when no 
encoding is determined. Ruby when querying the system SHGetFileInfo 
returns an ascii 8bit string and this pull request forces it to 
use whatever the system encoding default is set to.
