### PR TITLE
Fix INVALID_FILE_ATTRIBUTES for x64

### DIFF
--- a/lib/win32/dir/constants.rb
+++ b/lib/win32/dir/constants.rb
@@ -19,5 +19,5 @@ module Dir::Constants
   SHGFI_PIDL                   = 0x000000008
 
   INVALID_HANDLE_VALUE    = FFI::Pointer.new(-1).address
-  INVALID_FILE_ATTRIBUTES = FFI::Pointer.new(-1).address
+  INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
 end


### PR DESCRIPTION
- The GetFileAttributes Win32 API call returns a DWORD, which is a platform independent 32-bit wide
  unsigned integer:
  http://msdn.microsoft.com/en-us/library/windows/desktop/aa364944(v=vs.85).aspx
  It's max value is 4294967295:
  http://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
- FFI::Pointer.new(-1).address is platform dependent and on x64 is 18446744073709551615, which is
  the max value of a 64-bit wide unsigned integer.
- The INVALID_FILE_ATTRIBUTES constant is a valid return value of GetFileAttributes and is defined in winbase.h as:
  #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
- Therefore INVALID_FILE_ATTRIBUTES should be defined as 0xFFFFFFFF
