### PR TITLE
Remove require rubygems in the gemspec

### DIFF
--- a/win32-dir.gemspec
+++ b/win32-dir.gemspec
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 Gem::Specification.new do |spec|
   spec.name       = 'win32-dir'
   spec.version    = '0.5.1'


### PR DESCRIPTION
Modern ruby releases no longer require this.

Signed-off-by: Tim Smith <tsmith@chef.io>