### PR TITLE
Require Ruby 2.2 and only ship required libs

### DIFF
--- a/win32-dir.gemspec
+++ b/win32-dir.gemspec
@@ -4,13 +4,12 @@ Gem::Specification.new do |spec|
   spec.authors    = ['Daniel J. Berger', 'Park Heesob']
   spec.license    = 'Artistic 2.0'
   spec.email      = 'djberg96@gmail.com'
-  spec.homepage   = 'http://github.com/chef/win32-dir'
+  spec.homepage   = 'https://github.com/chef/win32-dir'
   spec.summary    = 'Extra constants and methods for the Dir class on Windows.'
-  spec.test_file  = 'test/test_win32_dir.rb'
-  spec.files      = Dir['**/*'].reject{ |f| f.include?('git') }
+  spec.files         = Dir["LICENSE", "lib/**/*"]
+  spec.require_paths = ["lib"]
 
-  spec.extra_rdoc_files  = ['README.md', 'CHANGELOG.md']
-  spec.required_ruby_version = '>= 1.9.2'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency('ffi', '>= 1.0.0')
 


### PR DESCRIPTION
Require a modern ruby version

Signed-off-by: Tim Smith <tsmith@chef.io>