### PR TITLE
Move version into its own ruby file

### DIFF
--- a/lib/win32/dir.rb
+++ b/lib/win32/dir.rb
@@ -7,9 +7,6 @@ class Dir
   include Dir::Constants
   extend Dir::Functions
 
-  # The version of the win32-dir library.
-  VERSION = "0.6.2"
-
   # CSIDL constants
   csidl = Hash[
     "DESKTOP",                  0x0000,

--- a/lib/win32/dir/version.rb
+++ b/lib/win32/dir/version.rb
@@ -1,0 +1,6 @@
+module Win32
+  class Dir
+    # The version of the win32-taskscheduler library
+    VERSION = "0.6.1".freeze
+  end
+end

--- a/win32-dir.gemspec
+++ b/win32-dir.gemspec
@@ -1,6 +1,8 @@
+require_relative "lib/win32/dir/version"
+
 Gem::Specification.new do |spec|
   spec.name       = "win32-dir"
-  spec.version    = "0.5.1"
+  spec.version    = Win32::Dir::VERSION
   spec.authors    = ["Daniel J. Berger", "Park Heesob"]
   spec.license    = "Artistic 2.0"
   spec.email      = "djberg96@gmail.com"


### PR DESCRIPTION
This allows you to release it from a *nix system without loading the
complete gem.

Signed-off-by: Tim Smith <tsmith@chef.io>