### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/win32/dir/constants.rb
+++ b/lib/win32/dir/constants.rb
@@ -1,4 +1,4 @@
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 module Dir::Constants
   include FFI::Library

--- a/lib/win32/dir/functions.rb
+++ b/lib/win32/dir/functions.rb
@@ -1,10 +1,10 @@
 # Necessary to force JRuby to use the gem, not its builtin version
 if RUBY_PLATFORM == "java"
-  require "rubygems"
+  require "rubygems" unless defined?(Gem)
   gem "ffi"
 end
 
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 module Dir::Functions
   module FFI::Library

--- a/lib/win32/dir/structs.rb
+++ b/lib/win32/dir/structs.rb
@@ -1,4 +1,4 @@
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 module Dir::Structs
   extend FFI::Library


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>