### PR TITLE
Fix segfault if high-entropy 64-bit ASLR is enabled

### DIFF
--- a/lib/win32/dir/functions.rb
+++ b/lib/win32/dir/functions.rb
@@ -27,7 +27,7 @@ module Dir::Functions
 
   attach_pfunc :SHGetFolderPathW, %i{hwnd int handle dword buffer_out}, :dword
   attach_pfunc :SHGetFolderLocation, %i{hwnd int handle dword ptr}, :dword
-  attach_pfunc :SHGetFileInfo, %i{dword dword ptr uint uint}, :dword
+  attach_pfunc :SHGetFileInfo, %i{uint64 dword ptr uint uint}, :dword
 
   ffi_lib :shlwapi
   ffi_convention :stdcall


### PR DESCRIPTION
If the High-entropy ASLR setting is enabled on Windows, `win32/dir` will segfault when calling `SHGetFileInfo`.

Enabling high-entropy ASLR will cause processes to use the entire 64-bit address space, and the `long` data type is not large enough to hold a 64-bit address for the PIDL structure (which is the first argument of `SHGetFileInfo`[1]). As a result, the call segfaults.

[1] https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shgetfileinfow

### Description

Change the parameter's data type to `uint64` to ensure the PIDL address will always fit.

### Issues Resolved

https://tickets.puppetlabs.com/browse/PUP-10622

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
