### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,35 +22,38 @@ github:
   # allow bumping the major release via label
   major_bump_labels:
     - "Expeditor: Bump Version Major"
-  # Which Github branches to build releases from, and what versions
-  # (as determined by the value in the VERSION file) those branches are responsible
-  # for building.
-  release_branch:
-    - master:
-        version_constraint: "*"
+
+# Which Github branches to build releases from, and what versions
+# (as determined by the value in the VERSION file) those branches are responsible
+# for building.
+release_branches:
+  - master:
+      version_constraint: "*"
 
 changelog:
   rollup_header: Changes not yet released to rubygems.org
 
-# These actions are taken, in order they are specified, anytime a Pull Request is merged.
-merge_actions:
-  - built_in:bump_version:
-      ignore_labels:
-        - "Expeditor: Skip Version Bump"
-        - "Expeditor: Skip All"
-  - bash:.expeditor/update_version.sh:
-      only_if: built_in:bump_version
-  - built_in:update_changelog:
-      ignore_labels:
-        - "Expeditor: Skip Changelog"
-        - "Expeditor: Skip All"
-  - built_in:build_gem:
-      only_if: built_in:bump_version
+subscriptions:
+  # These actions are taken, in order they are specified, anytime a Pull Request is merged.
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+          ignore_labels:
+            - "Expeditor: Skip Version Bump"
+            - "Expeditor: Skip All"
+      - bash:.expeditor/update_version.sh:
+          only_if: built_in:bump_version
+      - built_in:update_changelog:
+          ignore_labels:
+            - "Expeditor: Skip Changelog"
+            - "Expeditor: Skip All"
+      - built_in:build_gem:
+          only_if: built_in:bump_version
 
-promote:
-  actions:
-    - built_in:rollover_changelog
-    - built_in:publish_rubygems
+  - workload: project_promoted:{{agent_id}}:*
+    actions: 
+      - built_in:rollover_changelog
+      - built_in:publish_rubygems       
 
 pipelines:
   - verify:


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii) The promote block has been deprecated. All actions should be declared via the subscriptions block for clarity.
iii)  Release branches are a first-class concept in Expeditor, and should be represented as such.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
